### PR TITLE
fix: harden markdown image sanitizer

### DIFF
--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -28,5 +28,24 @@ describe('renderMarkdown', () => {
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
     expect(html).not.toContain('<script>');
   });
+
+  it('escapes image sources to prevent attribute injection', () => {
+    const html = renderMarkdown('![x](https://example.com" onerror="alert(1))');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('data-md-image-placeholder="true"');
+    expect(html).not.toContain('onerror');
+  });
+
+  it('html-escapes quotes inside image src attributes', () => {
+    const html = renderMarkdown('![x](https://example.com?foo="bar")');
+    expect(html).toContain('<img');
+    expect(html).toContain('src="https://example.com?foo=&quot;bar&quot;"');
+  });
+
+  it('rejects disallowed image schemes', () => {
+    const html = renderMarkdown('![x](javascript:alert(1))');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('data-md-image-placeholder="true"');
+  });
 });
 


### PR DESCRIPTION
## Summary
- escape markdown image attributes and validate allowed link schemes
- render placeholders for unsupported image references while keeping layout intact
- extend markdown tests for injection and script URL scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19a9dcd8c83309eae660d9c9d96a7