### PR TITLE
test: cover chatbot integration

### DIFF
--- a/src/lib/client/chat.test.ts
+++ b/src/lib/client/chat.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '$lib/types/chat';
+import { sendChatMessage } from './chat';
+
+function createMockResponse(body: unknown, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init
+  });
+}
+
+describe('sendChatMessage', () => {
+  it('posts the message and history to the chat endpoint', async () => {
+    const history: ChatMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Greetings' }
+    ];
+    const fetcher = vi.fn().mockResolvedValue(createMockResponse({ response: 'Hey there' }));
+
+    const result = await sendChatMessage({ message: 'How are you?', history, fetcher });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('/api/chat', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        message: 'How are you?',
+        history
+      })
+    });
+    expect(result).toEqual({ response: 'Hey there' });
+  });
+
+  it('throws when the endpoint responds with a non-OK status', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(createMockResponse({ error: 'Bad things' }, { status: 500, statusText: 'Internal Error' }));
+
+    await expect(sendChatMessage({ message: 'Test', fetcher })).rejects.toThrow(
+      'Chat request failed with status 500'
+    );
+  });
+
+  it('throws when the response payload is missing the response field', async () => {
+    const fetcher = vi.fn().mockResolvedValue(createMockResponse({ something: 'else' }));
+
+    await expect(sendChatMessage({ message: 'Test', fetcher })).rejects.toThrow(
+      'Invalid payload from chat endpoint'
+    );
+  });
+});

--- a/src/lib/server/chat/prompt.test.ts
+++ b/src/lib/server/chat/prompt.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { tundraSystemPrompt } from './prompts/tundra';
+import { buildChatPrompt } from './prompt';
+
+describe('buildChatPrompt', () => {
+  it('includes the system prompt, context, history, and trimmed user message', () => {
+    const prompt = buildChatPrompt({
+      userMessage: '  Report status  ',
+      history: [
+        { role: 'user', content: 'First contact' },
+        { role: 'assistant', content: 'Acknowledged' }
+      ],
+      contextSlices: ['Lore fragment A', 'Lore fragment B']
+    });
+
+    const expected = [
+      tundraSystemPrompt.trim(),
+      '--- CONTEXT ---',
+      'Lore fragment A\n\nLore fragment B',
+      ['Human: First contact', '', 'Tundra: Acknowledged', '', 'Human: Report status', '', 'Tundra:'].join('\n')
+    ].join('\n\n');
+
+    expect(prompt).toBe(expected);
+  });
+
+  it('omits context sections and empty history entries', () => {
+    const prompt = buildChatPrompt({
+      userMessage: '   Ping   ',
+      history: [
+        { role: 'user', content: '   ' },
+        { role: 'assistant', content: '' }
+      ]
+    });
+
+    expect(prompt.startsWith(tundraSystemPrompt.trim())).toBe(true);
+    expect(prompt).not.toContain('--- CONTEXT ---');
+    expect(prompt).toContain('Human: Ping');
+    expect(prompt).toContain('Tundra:');
+    expect(prompt).not.toContain('Human:    ');
+  });
+});

--- a/src/routes/api/chat/chat.server.test.ts
+++ b/src/routes/api/chat/chat.server.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/llm/llama', () => ({
+  requestCompletion: vi.fn()
+}));
+
+import { requestCompletion } from '$lib/server/llm/llama';
+import { POST } from './+server';
+
+const requestCompletionMock = vi.mocked(requestCompletion);
+
+function createRequest(body: unknown): Request {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body)
+  });
+}
+
+describe('POST /api/chat', () => {
+  beforeEach(() => {
+    requestCompletionMock.mockReset();
+  });
+
+  it('returns 400 when the payload is not valid JSON', async () => {
+    const response = await POST({ request: createRequest('{') } as any);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid JSON payload.' });
+  });
+
+  it('returns 400 when the message is missing or blank', async () => {
+    const response = await POST({ request: createRequest({ message: '   ' }) } as any);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Message is required.' });
+  });
+
+  it('sanitizes history and forwards the prompt to llama.cpp', async () => {
+    requestCompletionMock.mockResolvedValue('LLM ack');
+
+    const rawHistory = [
+      { role: 'user', content: '  Ignored   ' },
+      { role: 'assistant', content: '  Also ignored ' },
+      { role: 'assistant', content: '' },
+      { role: 'system', content: 'nope' },
+      'noise',
+      ...Array.from({ length: 14 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: ` Message ${index} `
+      }))
+    ];
+
+    const response = await POST(
+      {
+        request: createRequest({
+          message: '   Let\'s talk power.  ',
+          history: rawHistory
+        })
+      } as any
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ response: 'LLM ack' });
+
+    expect(requestCompletionMock).toHaveBeenCalledTimes(1);
+    const promptArg = requestCompletionMock.mock.calls[0][0]?.prompt as string;
+
+    expect(promptArg).toContain('Human: Message 2');
+    expect(promptArg).toContain('Tundra: Message 3');
+    expect(promptArg).not.toContain('Message 0');
+    expect(promptArg).toContain("Human: Let's talk power.");
+    expect(promptArg.trim().endsWith('Tundra:')).toBe(true);
+  });
+
+  it('falls back to a canned line when llama.cpp returns an empty string', async () => {
+    requestCompletionMock.mockResolvedValue('');
+
+    const response = await POST({ request: createRequest({ message: 'Hello' }) } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      response: "*Tundra tilts his head.* I lost the thread there -- give me another cue?"
+    });
+  });
+
+  it('returns 502 when llama.cpp cannot be reached', async () => {
+    requestCompletionMock.mockRejectedValue(new Error('offline'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await POST({ request: createRequest({ message: 'Test' }) } as any);
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: 'Unable to contact Tyrium relay.' });
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the chat client helper and prompt builder
- add API route tests that exercise history sanitisation, success, and failure cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19c235f448330aee061e07307738e